### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,8 @@
-[![Latest Version](https://pypip.in/version/dotfilemanager/badge.svg)](https://pypi.python.org/pypi/dotfilemanager/)
-[![Downloads](https://pypip.in/download/dotfilemanager/badge.svg)](https://pypi.python.org/pypi/dotfilemanager/)
-[![Supported Python versions](https://pypip.in/py_versions/dotfilemanager/badge.svg)](https://pypi.python.org/pypi/dotfilemanager/)
-[![Development Status](https://pypip.in/status/dotfilemanager/badge.svg)](https://pypi.python.org/pypi/dotfilemanager/)
-[![License](https://pypip.in/license/dotfilemanager/badge.svg)](https://pypi.python.org/pypi/dotfilemanager/)
+[![Latest Version](https://img.shields.io/pypi/v/dotfilemanager.svg)](https://pypi.python.org/pypi/dotfilemanager/)
+[![Downloads](https://img.shields.io/pypi/dm/dotfilemanager.svg)](https://pypi.python.org/pypi/dotfilemanager/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/dotfilemanager.svg)](https://pypi.python.org/pypi/dotfilemanager/)
+[![Development Status](https://img.shields.io/pypi/status/dotfilemanager.svg)](https://pypi.python.org/pypi/dotfilemanager/)
+[![License](https://img.shields.io/pypi/l/dotfilemanager.svg)](https://pypi.python.org/pypi/dotfilemanager/)
 
 dotfilemanager.py
 =================


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20dotfilemanager))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `dotfilemanager`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.